### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/cloudformation/continuous-integration-branch-checks.yml
+++ b/cloudformation/continuous-integration-branch-checks.yml
@@ -160,7 +160,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: slack_notifications.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       CodeUri: ../ci_tools
       Description: >-
         Sends message to Slack channel when branch-check builds fail

--- a/cloudformation/continuous-integration-nightly-checks.yml
+++ b/cloudformation/continuous-integration-nightly-checks.yml
@@ -151,7 +151,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: email_notifications.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       CodeUri: ../ci_tools
       Description: >-
         Sends emails when builds fail

--- a/cloudformation/continuous-integration-pull-request-checks.yml
+++ b/cloudformation/continuous-integration-pull-request-checks.yml
@@ -202,7 +202,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: codecommit_pr_notifications.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       CodeUri: ../ci_tools
       Description: >-
         Comment on the CodeCommit pull request when a build is triggered and when it completes


### PR DESCRIPTION
CloudFormation templates in aws-codebuild-samples have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.